### PR TITLE
Cleaner dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,16 @@
 FROM alpine:3.13.5 as builder
-MAINTAINER steve@the-steve.com
+LABEL MAINTAINER "Stephen Hunter" <steve@the-steve.com>
 # Change VERSION any branch in git repo. Defaults to version 23.x
 ARG VERSION=22.x
 # Default is 4, but change this to whatever works for your system
 ARG BUILDCORES=4
-# Download all needed packages, clone git repo and compile
-RUN apk --update upgrade && \
-    apk add gcc git make autoconf libtool automake pkgconfig g++ boost-dev libevent-dev db-dev && \
-    rm -fr /var/cache/apk/* && \
-    git clone https://github.com/bitcoin/bitcoin /bitcoin-core-src && \
-    cd /bitcoin-core-src && \
-    git checkout ${VERSION} && \
+RUN apk add -U autoconf automake bash bison boost-dev build-base curl db-dev git libevent-dev libtool linux-headers make pkgconf python3 xz && \
+    git clone --branch "${VERSION}" --single-branch https://github.com/bitcoin/bitcoin.git /bitcoin && \
+    cd /bitcoin/ && \
+    make -C depends/ -j "${BUILDCORES}" && \
     ./autogen.sh && \
-    ./configure --with-incompatible-bdb && \
-    make -j ${BUILDCORES} && \
-    make check && \
-    ./test/functional/test_runner.py --extended && \
-    mkdir /bitcoin && cd src && cp bitcoind bitcoin-cli bitcoin-tx bitcoin-util /bitcoin
+    CONFIG_SITE=/bitcoin/depends/x86_64-pc-linux-musl/share/config.site ./configure --without-gui --without-miniupnpc --without-natpmp && \
+    make -j "${BUILDCORES}"
 
 FROM alpine:3.13.5
 MAINTAINER steve@the-steve.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,10 @@ RUN apk add -U autoconf automake bash bison boost-dev build-base curl db-dev git
     CONFIG_SITE=/bitcoin/depends/x86_64-pc-linux-musl/share/config.site ./configure --without-gui --without-miniupnpc --without-natpmp && \
     make -j "${BUILDCORES}"
 
-FROM alpine:3.13.5
-MAINTAINER steve@the-steve.com
+FROM scratch
+LABEL MAINTAINER "Stephen Hunter" <steve@the-steve.com>
 ENV HOME /bitcoin/data
 EXPOSE 8333
-RUN apk --update upgrade && \
-    apk add libtool pkgconfig boost-dev libevent-dev db-dev && \
-    rm -fr /var/cache/apk/* && \
-    mkdir -p /bitcoin && \
-    mkdir /bitcoin/data
-COPY --from=builder /bitcoin/* /bitcoin/bin/
-COPY entrypoint.sh /bitcoin/bin/
-ENTRYPOINT ["/bin/sh"]
-#ENTRYPOINT ["/bitcoin/bin/entrypoint.sh"]
-#CMD ["startd"]
+COPY --from=builder /bitcoin/src/bitcoind /bitcoin/src/bitcoin-cli /bitcoin/src/bitcoin-tx /bitcoin/src/bitcoin-util /bin/
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /lib/
+CMD ["/bin/bitcoind"]


### PR DESCRIPTION
Improves production image

    * Do not use Alpine, use blank image
    * Copy binaries to standard directories
    * Set a default command, no entrypoint
    * Correct maintainer label

Improves build image

    * Build directly for libmusl instead of glibc
    * Disable UPnP
    * Don't remove /var/cache/apt in build image
    * Only clone needed bitcoin branch
    * Static build